### PR TITLE
Increase size of 'cname' member of struct resourcerecord to 1024 from 64

### DIFF
--- a/ldap2dns.c
+++ b/ldap2dns.c
@@ -106,7 +106,7 @@ struct resourcerecord
 	char type[16];
 	char ipaddr[256][80];
 	char cipaddr[80];
-	char cname[1024]; ## large enough to store DKIM entries, which by rfc5322 have an upper-limit of 998chars
+	char cname[1024]; /* large enough to store DKIM entries, which by rfc5322 have an upper-limit of 998chars */
 	char ttl[12];
 	char timestamp[20];
 	char preference[12];

--- a/ldap2dns.c
+++ b/ldap2dns.c
@@ -106,7 +106,7 @@ struct resourcerecord
 	char type[16];
 	char ipaddr[256][80];
 	char cipaddr[80];
-	char cname[64];
+	char cname[1024]; ## large enough to store DKIM entries, which by rfc5322 have an upper-limit of 998chars
 	char ttl[12];
 	char timestamp[20];
 	char preference[12];


### PR DESCRIPTION
This was causing DKIM entries (http://tools.ietf.org/html/rfc5585#page-12) to be truncated, since they are frequently longer than 64 chars.

DKIM signatures are the same as those in RFC 5322 (internet message format), which in the text says they may be as large as 998 chars (http://tools.ietf.org/html/rfc5322#section-2.1.1).

1024 seems like a reasonable, round number.
